### PR TITLE
Implemented GetMonthlyCost method

### DIFF
--- a/subtrack.MAUI/Services/SubscriptionsCalculator.cs
+++ b/subtrack.MAUI/Services/SubscriptionsCalculator.cs
@@ -4,7 +4,7 @@ namespace subtrack.MAUI.Services;
 
 public static class SubscriptionsCalculator
 {
-    public static decimal GetMonthlyCost(IEnumerable<Subscription> subscriptions)
+    public static decimal GetMonthlyCost(this IEnumerable<Subscription> subscriptions)
     {
         if (subscriptions is null || !subscriptions.Any()) return 0;
         var price = subscriptions.Sum(x => x.Cost);

--- a/subtrack.MAUI/Services/SubscriptionsCalculator.cs
+++ b/subtrack.MAUI/Services/SubscriptionsCalculator.cs
@@ -1,0 +1,13 @@
+﻿using subtrack.DAL.Entities;
+
+namespace subtrack.MAUI.Services;
+
+public static class SubscriptionsCalculator
+{
+    public static decimal GetMonthlyCost(IEnumerable<Subscription> subscriptions)
+    {
+        if (subscriptions is null || !subscriptions.Any()) return 0;
+        var price = subscriptions.Sum(x => x.Cost);
+        return price;
+    }
+}

--- a/subtrack.Tests/SubscriptionCalculatorTests/GetMonthlyCostTests.cs
+++ b/subtrack.Tests/SubscriptionCalculatorTests/GetMonthlyCostTests.cs
@@ -1,0 +1,55 @@
+﻿using subtrack.DAL.Entities;
+using subtrack.MAUI.Services;
+
+namespace subtrack.Tests.SubscriptionCalculatorTests;
+
+public class GetMonthlyCostTests
+{
+    [Fact]
+    public void GetMonthlyCost_EmptySubscriptions_ReturnsZero()
+    {
+        var subscriptions = new List<Subscription>();
+
+        var result = SubscriptionsCalculator.GetMonthlyCost(subscriptions);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void GetMonthlyCost_NullSubscriptions_ReturnsZero()
+    {
+        List<Subscription>? subscriptions = null;
+
+        var result = SubscriptionsCalculator.GetMonthlyCost(subscriptions);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void GetMonthlyCost_OneSubscription_ReturnsCorrectMonthlyCost()
+    {
+        var subscriptions = new List<Subscription>
+        {
+            new Subscription { Cost = 10.5m }
+        };
+
+        var result = SubscriptionsCalculator.GetMonthlyCost(subscriptions);
+
+        Assert.Equal(10.5m, result);
+    }
+
+    [Fact]
+    public void GetMonthlyCost_MultipleSubscriptions_ReturnsCorrectMonthlyCost()
+    {
+        var subscriptions = new List<Subscription>
+        {
+            new Subscription { Cost = 10.5m },
+            new Subscription { Cost = 5.25m },
+            new Subscription { Cost = 7.75m }
+        };
+
+        var result = SubscriptionsCalculator.GetMonthlyCost(subscriptions);
+
+        Assert.Equal(23.5m, result);
+    }
+}

--- a/subtrack.Tests/SubscriptionCalculatorTests/GetMonthlyCostTests.cs
+++ b/subtrack.Tests/SubscriptionCalculatorTests/GetMonthlyCostTests.cs
@@ -10,7 +10,7 @@ public class GetMonthlyCostTests
     {
         var subscriptions = new List<Subscription>();
 
-        var result = SubscriptionsCalculator.GetMonthlyCost(subscriptions);
+        var result = subscriptions.GetMonthlyCost();
 
         Assert.Equal(0, result);
     }
@@ -20,7 +20,7 @@ public class GetMonthlyCostTests
     {
         List<Subscription>? subscriptions = null;
 
-        var result = SubscriptionsCalculator.GetMonthlyCost(subscriptions);
+        var result = subscriptions.GetMonthlyCost();
 
         Assert.Equal(0, result);
     }
@@ -33,7 +33,7 @@ public class GetMonthlyCostTests
             new Subscription { Cost = 10.5m }
         };
 
-        var result = SubscriptionsCalculator.GetMonthlyCost(subscriptions);
+        var result = subscriptions.GetMonthlyCost();
 
         Assert.Equal(10.5m, result);
     }
@@ -48,7 +48,7 @@ public class GetMonthlyCostTests
             new Subscription { Cost = 7.75m }
         };
 
-        var result = SubscriptionsCalculator.GetMonthlyCost(subscriptions);
+        var result = subscriptions.GetMonthlyCost();
 
         Assert.Equal(23.5m, result);
     }


### PR DESCRIPTION
PR targets issue no. #3 

Changes Added:

- Implemented the `GetMonthlyCost` method in the `SubscriptionsCalculator` class.
- Added unit tests for the `GetMonthlyCost` method.

Details:

- The `GetMonthlyCost` method accepts an `IEnumerable<Subscription>` parameter representing the subscriptions for which the monthly cost needs to be calculated.
- The method handles edge cases by checking for null or empty subscriptions. If the subscriptions parameter is null or contains no elements, the method returns 0 as the monthly cost.
- Tests cover scenarios such as empty subscriptions, null subscriptions, a single subscription, and multiple subscriptions with varying costs.