### PR TITLE
#23 Refactored GetMonthlyCost method to not be an extension method

### DIFF
--- a/subtrack.MAUI/Pages/Index.razor
+++ b/subtrack.MAUI/Pages/Index.razor
@@ -28,6 +28,6 @@
     protected override void OnInitialized()
     {
         _subscriptions = Db.Subscriptions.ToList();
-        _subscriptionsCost = _subscriptions.GetMonthlyCost();
+        _subscriptionsCost = SubscriptionsCalculator.GetMonthlyCost(_subscriptions);
     }
 }

--- a/subtrack.MAUI/Services/SubscriptionsCalculator.cs
+++ b/subtrack.MAUI/Services/SubscriptionsCalculator.cs
@@ -4,7 +4,7 @@ namespace subtrack.MAUI.Services;
 
 public static class SubscriptionsCalculator
 {
-    public static decimal GetMonthlyCost(this IEnumerable<Subscription> subscriptions)
+    public static decimal GetMonthlyCost(IEnumerable<Subscription> subscriptions)
     {
         if (subscriptions is null || !subscriptions.Any()) return 0;
         var price = subscriptions.Sum(x => x.Cost);

--- a/subtrack.Tests/SubscriptionCalculatorTests/GetMonthlyCostTests.cs
+++ b/subtrack.Tests/SubscriptionCalculatorTests/GetMonthlyCostTests.cs
@@ -10,7 +10,7 @@ public class GetMonthlyCostTests
     {
         var subscriptions = new List<Subscription>();
 
-        var result = subscriptions.GetMonthlyCost();
+        var result = SubscriptionsCalculator.GetMonthlyCost(subscriptions);
 
         Assert.Equal(0, result);
     }
@@ -20,7 +20,7 @@ public class GetMonthlyCostTests
     {
         List<Subscription>? subscriptions = null;
 
-        var result = subscriptions.GetMonthlyCost();
+        var result = SubscriptionsCalculator.GetMonthlyCost(subscriptions);
 
         Assert.Equal(0, result);
     }
@@ -33,7 +33,7 @@ public class GetMonthlyCostTests
             new Subscription { Cost = 10.5m }
         };
 
-        var result = subscriptions.GetMonthlyCost();
+        var result = SubscriptionsCalculator.GetMonthlyCost(subscriptions);
 
         Assert.Equal(10.5m, result);
     }
@@ -48,7 +48,7 @@ public class GetMonthlyCostTests
             new Subscription { Cost = 7.75m }
         };
 
-        var result = subscriptions.GetMonthlyCost();
+        var result = SubscriptionsCalculator.GetMonthlyCost(subscriptions);
 
         Assert.Equal(23.5m, result);
     }


### PR DESCRIPTION
#### Changes
- Changed the `GetMonthlyCost` method to not be an extension method.
- Refactored `GetMonthlyCostTests` tests.
- Refactored `Index.razor` -> `OnInitialized()` to use the correct method.

Closes #23.