### PR TITLE
Fix long descriptions not being displayed correctly.

### DIFF
--- a/subtrack.MAUI/Pages/SubscriptionDetails.razor
+++ b/subtrack.MAUI/Pages/SubscriptionDetails.razor
@@ -58,10 +58,8 @@ else
         </div>
         @if (!string.IsNullOrWhiteSpace(_subscription.Description))
         {
-            <div class="row border-bottom py-2">
-                <div class="col-12 d-flex justify-content-center">
-                    @_subscription.Description
-                </div>
+            <div class="row border-bottom py-2 d-flex justify-content-center text-break">
+                @_subscription.Description
             </div>
         }
         <div class="row border-bottom py-2">

--- a/subtrack.MAUI/Pages/SubscriptionDetails.razor
+++ b/subtrack.MAUI/Pages/SubscriptionDetails.razor
@@ -1,4 +1,5 @@
 ﻿@page "/details/{Id:int}"
+@using subtrack.MAUI.Utilities;
 
 @inject ISubscriptionService subscriptionService
 @inject NavigationManager navigationManager


### PR DESCRIPTION
Closes #57 

# Changes
- Added the `text-break` class on the subscription div to

> Documentation for `text-break` : https://getbootstrap.com/docs/5.3/utilities/text/#word-break

# Acceptance criteria

![image](https://github.com/Code2Gether-Discord/subtrack/assets/7747808/5d22a226-c99b-4b00-b943-1e0c1ae91f44)

