### PR TITLE
Add maximum title length validation for subscriptions

### DIFF
--- a/subtrack.DAL/Entities/Subscription.cs
+++ b/subtrack.DAL/Entities/Subscription.cs
@@ -7,6 +7,7 @@ public class Subscription
     public int Id { get; set; }
 
     [Required]
+    [StringLength(20,ErrorMessage = "Service name should be less than 20 characters")]
     public string Name { get; set; } = null!;
     public string? Description { get; set; }
     public bool IsAutoPaid { get; set; }

--- a/subtrack.DAL/Entities/Subscription.cs
+++ b/subtrack.DAL/Entities/Subscription.cs
@@ -7,7 +7,7 @@ public class Subscription
     public int Id { get; set; }
 
     [Required]
-    [StringLength(20,ErrorMessage = "Service name should be less than 20 characters.")]
+    [StringLength(12,ErrorMessage = "Service name should be less than 12 characters.")]
     public string Name { get; set; } = null!;
     public string? Description { get; set; }
     public bool IsAutoPaid { get; set; }

--- a/subtrack.DAL/Entities/Subscription.cs
+++ b/subtrack.DAL/Entities/Subscription.cs
@@ -7,7 +7,7 @@ public class Subscription
     public int Id { get; set; }
 
     [Required]
-    [StringLength(20,ErrorMessage = "Service name should be less than 20 characters")]
+    [StringLength(20,ErrorMessage = "Service name should be less than 20 characters.")]
     public string Name { get; set; } = null!;
     public string? Description { get; set; }
     public bool IsAutoPaid { get; set; }

--- a/subtrack.MAUI/Pages/SubscriptionDetails.razor
+++ b/subtrack.MAUI/Pages/SubscriptionDetails.razor
@@ -18,7 +18,7 @@ else
                 <BackButton Url="@ReturnUrl"></BackButton>
             </div>
             <div>
-                <h2 class="ps-2 text-break">@_subscription.Name</h2>
+                <h2 class="ps-3 text-break">@_subscription.Name</h2>
             </div>
             <div>
                 <button aria-label="Edit" type="button" class="btn btn-outline-info"><i class="bi bi-pencil-square"></i></button>

--- a/subtrack.MAUI/Pages/SubscriptionDetails.razor
+++ b/subtrack.MAUI/Pages/SubscriptionDetails.razor
@@ -18,7 +18,7 @@ else
                 <BackButton Url="@ReturnUrl"></BackButton>
             </div>
             <div>
-                <h2>@_subscription.Name</h2>
+                <h2 class="ps-2 text-break">@_subscription.Name</h2>
             </div>
             <div>
                 <button aria-label="Edit" type="button" class="btn btn-outline-info"><i class="bi bi-pencil-square"></i></button>


### PR DESCRIPTION
Closes #58 

# Changes
- Added max length for service name (12 characters) with error message `Service name should be less than 12 characters`
- Added `text-break` class to the name field so the name won't overflow and 2 padding to the start.

# Acceptance criteria

### Error message
![image](https://github.com/Code2Gether-Discord/subtrack/assets/7747808/52e60550-47ea-4132-857e-2c724032a677)

### Sub details
![image](https://github.com/Code2Gether-Discord/subtrack/assets/7747808/f3c9e43b-f1bf-4c99-a7d3-a70eea50dd6f)

### Home
![image](https://github.com/Code2Gether-Discord/subtrack/assets/7747808/526280dd-2ed7-4f03-a604-11c6acffe37b)
