### PR TITLE
Configured SQLite in-memory for testing.

### DIFF
--- a/subtrack.Tests/SubscriptionCalculatorTests/IntegrationTest.cs
+++ b/subtrack.Tests/SubscriptionCalculatorTests/IntegrationTest.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Data.Common;
+using System.Linq;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using subtrack.DAL;
+using subtrack.DAL.Entities;
+using Xunit;
+
+
+public abstract class SqliteInMemoryTest : IDisposable
+{
+    private readonly DbConnection _connection;
+    private readonly DbContextOptions<SubtrackDbContext> _contextOptions;
+    protected SubtrackDbContext _dbContext;
+
+    public SqliteInMemoryTest()
+    {
+        // Create and open a connection. This creates the SQLite in-memory database, which will persist until the connection is closed
+        // at the end of the test (see Dispose below).
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
+
+        // These options will be used by the context instances in this test suite, including the connection opened above.
+        _contextOptions = new DbContextOptionsBuilder<SubtrackDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        _dbContext = new SubtrackDbContext(_contextOptions);
+
+        using var context = new SubtrackDbContext(_contextOptions);
+
+        context.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+}

--- a/subtrack.Tests/SubscriptionCalculatorTests/IntegrationTestBase.cs
+++ b/subtrack.Tests/SubscriptionCalculatorTests/IntegrationTestBase.cs
@@ -7,14 +7,14 @@ using subtrack.DAL;
 using subtrack.DAL.Entities;
 using Xunit;
 
-namespace EF.Testing.UnitTests;
 
-public class SqliteInMemoryBloggingControllerTest : IDisposable
+public abstract class SqliteInMemoryControllerTest : IDisposable
 {
     private readonly DbConnection _connection;
     private readonly DbContextOptions<SubtrackDbContext> _contextOptions;
+    protected SubtrackDbContext _dbContext;
 
-    public SqliteInMemoryBloggingControllerTest()
+    public SqliteInMemoryControllerTest()
     {
         // Create and open a connection. This creates the SQLite in-memory database, which will persist until the connection is closed
         // at the end of the test (see Dispose below).
@@ -26,25 +26,17 @@ public class SqliteInMemoryBloggingControllerTest : IDisposable
             .UseSqlite(_connection)
             .Options;
 
-        // Create the schema and seed some data
+        _dbContext = new SubtrackDbContext(_contextOptions);
+
         using var context = new SubtrackDbContext(_contextOptions);
 
         if (context.Database.EnsureCreated())
         {
             using var viewCommand = context.Database.GetDbConnection().CreateCommand();
-            viewCommand.CommandText = @"
-CREATE VIEW AllResources AS
-SELECT *
-FROM Subscriptions;";
-            viewCommand.ExecuteNonQuery();
+
         }
-        context.AddRange(
-            new Subscription { Id = 1, Name = "water", Cost = 12.00m, IsAutoPaid = true, LastPayment = DateTime.Today });
-        context.SaveChanges();
     }
 
-    SubtrackDbContext CreateContext() => new SubtrackDbContext(_contextOptions);
-
-    public void Dispose() => _connection.Dispose();
+    public void Dispose() => _dbContext.Dispose();
 
 }

--- a/subtrack.Tests/SubscriptionCalculatorTests/IntegrationTestBase.cs
+++ b/subtrack.Tests/SubscriptionCalculatorTests/IntegrationTestBase.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Data.Common;
+using System.Linq;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using subtrack.DAL;
+using subtrack.DAL.Entities;
+using Xunit;
+using subtrack.MAUI.Services;
+
+namespace EF.Testing.UnitTests;
+
+public class SqliteInMemoryBloggingControllerTest : IDisposable
+{
+    private readonly DbConnection _connection;
+    private readonly DbContextOptions<SubtrackDbContext> _contextOptions;
+
+    public SqliteInMemoryBloggingControllerTest()
+    {
+        // Create and open a connection. This creates the SQLite in-memory database, which will persist until the connection is closed
+        // at the end of the test (see Dispose below).
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
+
+        // These options will be used by the context instances in this test suite, including the connection opened above.
+        _contextOptions = new DbContextOptionsBuilder<SubtrackDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        // Create the schema and seed some data
+        using var context = new SubtrackDbContext(_contextOptions);
+
+        if (context.Database.EnsureCreated())
+        {
+            using var viewCommand = context.Database.GetDbConnection().CreateCommand();
+            viewCommand.CommandText = @"
+CREATE VIEW AllResources AS
+SELECT *
+FROM Subscriptions;";
+            viewCommand.ExecuteNonQuery();
+        }
+        context.AddRange(
+            new Subscription { Id = 1, Name = "water", Cost = 12.00m, IsAutoPaid = true, LastPayment = DateTime.Today });
+        context.SaveChanges();
+    }
+
+    SubtrackDbContext CreateContext() => new SubtrackDbContext(_contextOptions);
+
+    public void Dispose() => _connection.Dispose();
+
+}

--- a/subtrack.Tests/SubscriptionCalculatorTests/IntegrationTestBase.cs
+++ b/subtrack.Tests/SubscriptionCalculatorTests/IntegrationTestBase.cs
@@ -6,7 +6,6 @@ using Microsoft.EntityFrameworkCore;
 using subtrack.DAL;
 using subtrack.DAL.Entities;
 using Xunit;
-using subtrack.MAUI.Services;
 
 namespace EF.Testing.UnitTests;
 


### PR DESCRIPTION
Configured in-memory SQLite for testing as in https://github.com/dotnet/EntityFramework.Docs/blob/main/samples/core/Testing/TestingWithoutTheDatabase/SqliteInMemoryBloggingControllerTest.cs . Closes #71