### PR TITLE
#73 Added autopaid filtering

### DIFF
--- a/subtrack.MAUI/Services/Abstractions/ISubscriptionService.cs
+++ b/subtrack.MAUI/Services/Abstractions/ISubscriptionService.cs
@@ -1,10 +1,11 @@
 ﻿using subtrack.DAL.Entities;
+using subtrack.MAUI.Utilities;
 
 namespace subtrack.MAUI.Services.Abstractions
 {
     public interface ISubscriptionService
     {
-        Task<IEnumerable<Subscription>> GetSubscriptions();
+        Task<IEnumerable<Subscription>> GetSubscriptions(GetSubscriptionsFilter? filter = null);
         Task<Subscription> CreateSubscriptionAsync(Subscription subscriptionToCreate);
         Task<Subscription?> GetById(int id);
         Task Delete(int id);

--- a/subtrack.MAUI/Services/SubscriptionService.cs
+++ b/subtrack.MAUI/Services/SubscriptionService.cs
@@ -14,9 +14,11 @@ namespace subtrack.MAUI.Services
 
         public async Task<IEnumerable<Subscription>> GetSubscriptions(GetSubscriptionsFilter? filter = null)
         {
-            bool shouldFilter = filter != null;
+            if (filter is not null) return await _context.Subscriptions
+                    .WhereIf(sub => sub.IsAutoPaid == filter.AutoPaid, filter.AutoPaid is not null)
+                    .ToListAsync();
 
-            return await _context.Subscriptions.WhereIf(filter?.GetAutoPaidFilter(), shouldFilter).ToListAsync();
+            return await _context.Subscriptions.ToListAsync();
         }
 
         public async Task Update(Subscription subscriptionToUpdate)

--- a/subtrack.MAUI/Services/SubscriptionService.cs
+++ b/subtrack.MAUI/Services/SubscriptionService.cs
@@ -3,6 +3,7 @@ using subtrack.DAL;
 using subtrack.DAL.Entities;
 using subtrack.MAUI.Exceptions;
 using subtrack.MAUI.Services.Abstractions;
+using subtrack.MAUI.Utilities;
 
 namespace subtrack.MAUI.Services
 {
@@ -11,9 +12,11 @@ namespace subtrack.MAUI.Services
         private readonly SubtrackDbContext _context;
         public SubscriptionService(SubtrackDbContext context) => _context = context;
 
-        public async Task<IEnumerable<Subscription>> GetSubscriptions()
+        public async Task<IEnumerable<Subscription>> GetSubscriptions(GetSubscriptionsFilter? filter = null)
         {
-            return await _context.Subscriptions.ToListAsync();
+            bool shouldFilter = filter != null;
+
+            return await _context.Subscriptions.WhereIf(filter?.GetAutoPaidFilter(), shouldFilter).ToListAsync();
         }
 
         public async Task Update(Subscription subscriptionToUpdate)

--- a/subtrack.MAUI/Utilities/GetSubscriptionsFilter.cs
+++ b/subtrack.MAUI/Utilities/GetSubscriptionsFilter.cs
@@ -5,12 +5,5 @@ namespace subtrack.MAUI.Utilities;
 
 public class GetSubscriptionsFilter
 {
-	public Expression<Func<Subscription, bool>> _autoPaidFilter = sub => true;
-
-    public GetSubscriptionsFilter(bool useAutoPaidFilter)
-    {
-        if (useAutoPaidFilter) _autoPaidFilter = sub => sub.IsAutoPaid;
-    }
-
-    public Expression<Func<Subscription, bool>> GetAutoPaidFilter() { return _autoPaidFilter; }
+	public bool? AutoPaid { get; set; }
 }

--- a/subtrack.MAUI/Utilities/GetSubscriptionsFilter.cs
+++ b/subtrack.MAUI/Utilities/GetSubscriptionsFilter.cs
@@ -1,0 +1,16 @@
+﻿using subtrack.DAL.Entities;
+using System.Linq.Expressions;
+
+namespace subtrack.MAUI.Utilities;
+
+public class GetSubscriptionsFilter
+{
+	public Expression<Func<Subscription, bool>> _autoPaidFilter = sub => true;
+
+    public GetSubscriptionsFilter(bool useAutoPaidFilter)
+    {
+        if (useAutoPaidFilter) _autoPaidFilter = sub => sub.IsAutoPaid;
+    }
+
+    public Expression<Func<Subscription, bool>> GetAutoPaidFilter() { return _autoPaidFilter; }
+}

--- a/subtrack.MAUI/Utilities/QueryableExtensions.cs
+++ b/subtrack.MAUI/Utilities/QueryableExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System.Linq.Expressions;
+
+namespace subtrack.MAUI.Utilities;
+
+public static class QueryableExtensions
+{
+    public static IQueryable<TSource> WhereIf<TSource>(this IQueryable<TSource> source, Expression<Func<TSource,bool>>? filter, bool shouldFilter)
+    {
+        if(filter is not null && shouldFilter) source.Where(filter);
+        return source;
+    }
+}


### PR DESCRIPTION
# Changes
- Introduces a way to filter subscriptions by the AutoPaid field. 

# How to use
- To enable filtering by the AutoPaid field, simply set useAutoPaidFilter to trueat the instantiation of the GetSubscriptionsFilter class: 
    ```cs
    var useAutoPaidFilter = true;
    var filter = new GetSubscriptionsFilter(useAutoPaidFilter);
    ```
- Pass the filter to the GetSubscriptions method of the SubscriptionService to get the filtered subscriptions:
    ```cs
    var subscriptions = await subscriptionService.GetSubscriptions(filter);
    ```

Closes #73 