### PR TITLE
Allow for longer subscription titles and handle title overflow in subscription card

### DIFF
--- a/subtrack.DAL/Entities/Subscription.cs
+++ b/subtrack.DAL/Entities/Subscription.cs
@@ -7,7 +7,7 @@ public class Subscription
     public int Id { get; set; }
 
     [Required]
-    [StringLength(12,ErrorMessage = "Service name should be less than 12 characters.")]
+    [StringLength(20,ErrorMessage = "Service name should be less than 20 characters.")]
     public string Name { get; set; } = null!;
     public string? Description { get; set; }
     public bool IsAutoPaid { get; set; }

--- a/subtrack.DAL/Entities/Subscription.cs
+++ b/subtrack.DAL/Entities/Subscription.cs
@@ -7,7 +7,7 @@ public class Subscription
     public int Id { get; set; }
 
     [Required]
-    [StringLength(20,ErrorMessage = "Service name should be less than 20 characters.")]
+    [StringLength(50,ErrorMessage = "Service name should be less than 50 characters.")]
     public string Name { get; set; } = null!;
     public string? Description { get; set; }
     public bool IsAutoPaid { get; set; }

--- a/subtrack.MAUI/Pages/Index.razor
+++ b/subtrack.MAUI/Pages/Index.razor
@@ -26,17 +26,17 @@
         <div @onclick=@(() => Navigator.NavigateTo($"/details/{sub.Id}?ReturnUrl={Navigator.Uri}")) id="subscription-card" class="card border-primary mb-3 clickable" style="max-width: 20rem;">
             <div class="card-body" style="padding-top: 10px; padding-bottom: 10px;">
                 <div class="d-flex justify-content-between fs-5">
-                    <div>@sub.Name</div>
-                    <div class="text-right">@($"{sub.Cost:C}")</div>
+                    <div class="text-truncate flex-grow-1">@sub.Name</div>
+                    <div class="text-end flex-shrink-1" style="flex-basis: 7rem;">@($"{sub.Cost:C}")</div>
                 </div>
                 <div class="d-flex justify-content-between fs-6">
-                    <div class="text-left">
+                    <div class="text-start">
                         @if (sub.IsAutoPaid)
                         {
                             <i class="fa fa-repeat" aria-hidden="true"></i>
                         }
                     </div>
-                    <div class="text-right">@GetDueDaysText(sub.DueDays)</div>
+                    <div class="text-end">@GetDueDaysText(sub.DueDays)</div>
                 </div>
             </div>
         </div>

--- a/subtrack.MAUI/Pages/UpsertSubscription.razor
+++ b/subtrack.MAUI/Pages/UpsertSubscription.razor
@@ -46,7 +46,11 @@
 
     string _currency = "";
 
-    Subscription? _subscription = new();
+    Subscription? _subscription = new()
+        {
+            BillingInterval = 1,
+            BillingOccurrence = BillingOccurrence.Month // Temporary solution till #86 is in place
+        };
 
     protected override void OnInitialized()
     {

--- a/subtrack.MAUI/Shared/Components/SubscriptionMonthItem.razor
+++ b/subtrack.MAUI/Shared/Components/SubscriptionMonthItem.razor
@@ -14,12 +14,12 @@
         <div @onclick=@(() => Navigator.NavigateTo($"/details/{sub.Id}?ReturnUrl={Navigator.Uri}")) class="card mb-2 clickable" style="max-width: 20rem;">
             <div class="card-body" style="padding-top: 5px; padding-bottom: 5px;">
                 <div class="d-flex justify-content-between fs-5">
-                    <div>@sub.Name</div>
-                    <div class="text-right">@($"{sub.Cost:C}")</div>
+                    <div class="text-truncate flex-grow-1">@sub.Name</div>
+                    <div class="text-end flex-shrink-1" style="flex-basis: 7rem;">@($"{sub.Cost:C}")</div>
                 </div>
                 <div class="d-flex justify-content-between fs-6">
                     <div>@($"{sub.LastPayment.Day}{GetDateSuffix(sub.LastPayment.Day)}")</div>
-                    <div class="text-right">
+                    <div class="text-end">
                         @if (sub.IsAutoPaid)
                         {
                             <i class="fa fa-repeat" aria-hidden="true"></i>


### PR DESCRIPTION
Addresses #92 

- Increases title max length to 20
- Adds text truncation for titles in the main and monthly pages