### PR TITLE
Add details into subsciption details page.

### DIFF
--- a/subtrack.MAUI/Pages/SubscriptionDetails.razor
+++ b/subtrack.MAUI/Pages/SubscriptionDetails.razor
@@ -1,5 +1,6 @@
 ﻿@page "/details/{Id:int}"
 @using System.Globalization;
+@using System.Text;
 @using subtrack.MAUI.Utilities;
 @using subtrack.MAUI.Shared.Components
 @inject ISubscriptionService subscriptionService
@@ -26,6 +27,7 @@ else
             </div>
         </div>
         <div class="row border-bottom py-2">
+            <label>Billing cycle</label>
             <div class="col-12 d-flex justify-content-center">
                 <h5 class="d-inline-block">@($"{_subscription.Cost:C}")</h5>&nbsp;&nbsp;
                 @if (_subscription.IsAutoPaid)
@@ -33,9 +35,11 @@ else
                     <i class="fa fa-repeat" aria-hidden="true"></i>
                 }
             </div>
+            <label class="col-12 d-flex justify-content-center">@GetOccurance()</label>
         </div>
         <div class="row border-bottom py-2">
             <div class="col-12 d-flex flex-column justify-content-center">
+                <label>Next payment</label>
                 <div class="text-center">@_nextPaymentDate.ToString("MMMM dd, yyyy", _usCulture)</div>
                 <div class="text-center">@_dueTimeText</div>
             </div>
@@ -49,13 +53,15 @@ else
             </div>
         </div>
         <div class="row border-bottom py-2">
+            <label>Latest payment</label>
             <div class="col-12 d-flex justify-content-center">
                 Latest payment @_subscription.LastPayment.ToString("MMMM dd, yyyy", _usCulture)
             </div>
         </div>
         <div class="row border-bottom py-2">
+            <label>Annually</label>
             <div class="col-12 d-flex justify-content-center">
-                Annually - @($"{subscriptionsCalculator.GetYearlyCost(_subscription):C}")
+                @($"{subscriptionsCalculator.GetYearlyCost(_subscription):C}")
             </div>
         </div>
         @if (!string.IsNullOrWhiteSpace(_subscription.Description))
@@ -137,5 +143,19 @@ else
         }
         await subscriptionService.Delete(Id);
         navigationManager.NavigateTo("/", replace: true);
+    }
+    private string GetOccurance()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.Append("every ");
+        if(_subscription.BillingInterval==1)
+        {
+            sb.Append(_subscription.BillingOccurrence.Humanize().ToLower());
+            return sb.ToString();
+        }
+        sb.Append(_subscription.BillingInterval.ToWords());
+        sb.Append(" ");
+        sb.Append(_subscription.BillingOccurrence.Humanize().ToLower().Pluralize());
+        return sb.ToString();
     }
 }

--- a/subtrack.MAUI/Pages/SubscriptionDetails.razor
+++ b/subtrack.MAUI/Pages/SubscriptionDetails.razor
@@ -61,7 +61,7 @@ else
         <div class="row border-bottom py-2">
             <label>Annually</label>
             <div class="col-12 d-flex justify-content-center">
-                @($"{subscriptionsCalculator.GetYearlyCost(_subscription):C}")
+                @($"~{Math.Round(_subscriptionsCost, 2):C}")
             </div>
         </div>
         @if (!string.IsNullOrWhiteSpace(_subscription.Description))
@@ -82,6 +82,7 @@ else
 }
 
 @code {
+    private decimal _subscriptionsCost = 0;
     [Parameter]
     public int Id { get; set; }
 
@@ -103,6 +104,7 @@ else
     protected override async Task OnInitializedAsync()
     {
         _subscription = await subscriptionService.GetByIdIfExists(Id);
+        _subscriptionsCost = subscriptionsCalculator.GetYearlyCost(_subscription);
         _deleteButtonClicked = false;
         if (_subscription is not null)
         {

--- a/subtrack.MAUI/Pages/SubscriptionDetails.razor
+++ b/subtrack.MAUI/Pages/SubscriptionDetails.razor
@@ -35,7 +35,7 @@ else
                     <i class="fa fa-repeat" aria-hidden="true"></i>
                 }
             </div>
-            <label class="col-12 d-flex justify-content-center">@GetOccuranceText()</label>
+            <label class="col-12 d-flex justify-content-center">@GetOccurrenceText()</label>
         </div>
         <div class="row border-bottom py-2">
             <div class="col-12 d-flex flex-column justify-content-center">
@@ -144,7 +144,7 @@ else
         await subscriptionService.Delete(Id);
         navigationManager.NavigateTo("/", replace: true);
     }
-    private string GetOccuranceText()
+    private string GetOccurrenceText()
     {
         StringBuilder sb = new StringBuilder();
         sb.Append("every ");

--- a/subtrack.MAUI/Pages/SubscriptionDetails.razor
+++ b/subtrack.MAUI/Pages/SubscriptionDetails.razor
@@ -27,7 +27,7 @@ else
             </div>
         </div>
         <div class="row border-bottom py-2">
-            <label>Billing cycle</label>
+            <label>Billing</label>
             <div class="col-12 d-flex justify-content-center">
                 <h5 class="d-inline-block">@($"{_subscription.Cost:C}")</h5>&nbsp;&nbsp;
                 @if (_subscription.IsAutoPaid)
@@ -35,7 +35,7 @@ else
                     <i class="fa fa-repeat" aria-hidden="true"></i>
                 }
             </div>
-            <label class="col-12 d-flex justify-content-center">@GetOccurance()</label>
+            <label class="col-12 d-flex justify-content-center">@GetOccuranceText()</label>
         </div>
         <div class="row border-bottom py-2">
             <div class="col-12 d-flex flex-column justify-content-center">
@@ -144,7 +144,7 @@ else
         await subscriptionService.Delete(Id);
         navigationManager.NavigateTo("/", replace: true);
     }
-    private string GetOccurance()
+    private string GetOccuranceText()
     {
         StringBuilder sb = new StringBuilder();
         sb.Append("every ");


### PR DESCRIPTION
![Sub details](https://github.com/Code2Gether-Discord/subtrack/assets/53407843/8c8a46b3-3c25-4b0f-853e-ef6642e9bbfd)
In the mockup the billing cycle label and the occurrence are in one div. Should I make them into one or leave them inside the div with the payment cost for the selected occurrence? 