### PR TITLE
Feature/change apk filename to subtrack for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ After making changes to any entity you need to add a migration and update the da
 - Check if there are any open issues that are required for the release
 - Briefly test the app's functionality on the dev branch and open any necessary issues
 - Open a PR from dev to master branch that should contain the release number in the title
-  - The PR should update the application version `<ApplicationDisplayVersion></ApplicationDisplayVersion>` inside *subtrack.maui.csproj*. This should be set to the same value as the release version
+  - Update the application version `<ApplicationDisplayVersion></ApplicationDisplayVersion>` inside *subtrack.maui.csproj*. This should be set to the same value as the release version
+  - Update the Roadmap
 - Git pull master
 - Open up *subtrack.maui.csproj*
     - Set the value of application Id to `<ApplicationId>com.companyname.subtrack</ApplicationId>``

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Keep track of what subscriptions you have, when they have to be paid and how muc
   - [Github Issues](#github-issues)
   - [Creating database migrations](#creating-database-migrations)
   - [Design](#design)
+  - [Creating a Release](#creating-a-release)
 - [Roadmap 2023](#roadmap-2023)
 
 # Development Info
@@ -54,6 +55,25 @@ After making changes to any entity you need to add a migration and update the da
 ## Design
 - This project makes use of the cyborg theme from bootswatch https://bootswatch.com/cyborg/ and bootstrap v5.3.0
 - Mockups are created with drawio and any changes are saved as a png inside /docs
+
+## Creating a Release
+- Check if there are any open issues that are required for the release
+- Briefly test the app's functionality on the dev branch and open any necessary issues
+- Open a PR from dev to master branch that should contain the release number in the title
+  - The PR should update the application version `<ApplicationDisplayVersion></ApplicationDisplayVersion>` inside *subtrack.maui.csproj*. This should be set to the same value as the release version
+- Git pull master
+- Open up *subtrack.maui.csproj*
+    - Set the value of application Id to `<ApplicationId>com.companyname.subtrack</ApplicationId>``
+    - Set the value of application Title `<ApplicationTitle>subtrack</ApplicationTitle>`
+- Inside Visual Studio set build mode to **Release**
+- Build the project
+- Run the project
+- The APK file should have been created at this location: *subtrack.MAUI\bin\Release\net6.0-android\com.companyname.subtrack-Signed.apk*
+- Remove the changes that were made to the *.csproj* file
+- Upload the APK release to Github
+  - The version should be prefixed with a **"v"** and suffix of (app stage which is currently alpha 2/9-2023) **"-alpha"**
+  - Should contain notable changes/features that were added
+  - Should display the contributors
 
 # Roadmap 2023
 ![Roadmap 2023](docs/roadmap.png?)

--- a/subtrack.MAUI/subtrack.MAUI.csproj
+++ b/subtrack.MAUI/subtrack.MAUI.csproj
@@ -1,68 +1,68 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
-    <PropertyGroup>
-        <TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0</TargetFrameworks>
-        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
-        <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-        <!-- <TargetFrameworks>$(TargetFrameworks);net6.0-tizen</TargetFrameworks> -->
+	<PropertyGroup>
+		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
+		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
+		<!-- <TargetFrameworks>$(TargetFrameworks);net6.0-tizen</TargetFrameworks> -->
 		<OutputType Condition="'$(TargetFramework)' != 'net6.0'">Exe</OutputType>
-        <RootNamespace>subtrack.MAUI</RootNamespace>
-        <UseMaui>true</UseMaui>
+		<RootNamespace>subtrack.MAUI</RootNamespace>
+		<UseMaui>true</UseMaui>
 		<Nullable>enable</Nullable>
-        <SingleProject>true</SingleProject>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <EnableDefaultCssItems>false</EnableDefaultCssItems>
+		<SingleProject>true</SingleProject>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<EnableDefaultCssItems>false</EnableDefaultCssItems>
 
-        <!-- App Identifier -->
-        <ApplicationIdGuid>534AC803-FA5C-4FC7-9B68-B72408BE0A72</ApplicationIdGuid>
-		
-		<!-- Remove ".Test" when making an APK release but do not commit -->
-        <!-- Display name -->
-        <ApplicationTitle>subtrack.Test</ApplicationTitle>
 		<!-- App Identifier -->
-        <ApplicationId>com.companyname.subtrack.test</ApplicationId>
+		<ApplicationIdGuid>534AC803-FA5C-4FC7-9B68-B72408BE0A72</ApplicationIdGuid>
 
-        <!-- Versions -->
-        <ApplicationVersion>1</ApplicationVersion>
-        <!-- Update when merging from dev to master -->
-        <ApplicationDisplayVersion>1.0.0</ApplicationDisplayVersion>
+		<!-- Remove ".Test" when making an APK release but do not commit -->
+		<!-- Display name -->
+		<ApplicationTitle>subtrack.Test</ApplicationTitle>
+		<!-- App Identifier -->
+		<ApplicationId>com.companyname.subtrack.test</ApplicationId>
 
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
-        <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
-    </PropertyGroup>
+		<!-- Versions -->
+		<ApplicationVersion>1</ApplicationVersion>
+		<!-- Update when merging from dev to master -->
+		<ApplicationDisplayVersion>1.0.0</ApplicationDisplayVersion>
 
-    <ItemGroup>
-        <!-- App Icon -->
-        <MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
+		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
+	</PropertyGroup>
 
-        <!-- Splash Screen -->
-        <MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
+	<ItemGroup>
+		<!-- App Icon -->
+		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
 
-        <!-- Images -->
-        <MauiImage Include="Resources\Images\*" />
-        <MauiImage Update="Resources\Images\dotnet_bot.svg" BaseSize="168,208" />
+		<!-- Splash Screen -->
+		<MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
 
-        <!-- Custom Fonts -->
-        <MauiFont Include="Resources\Fonts\*" />
+		<!-- Images -->
+		<MauiImage Include="Resources\Images\*" />
+		<MauiImage Update="Resources\Images\dotnet_bot.svg" BaseSize="168,208" />
 
-        <!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
-        <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
-    </ItemGroup>
+		<!-- Custom Fonts -->
+		<MauiFont Include="Resources\Fonts\*" />
 
-    <ItemGroup>
-      <None Include="wwwroot\js\highlightInput.js" />
-    </ItemGroup>
+		<!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
+		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
+	</ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-    </ItemGroup>
+	<ItemGroup>
+		<None Include="wwwroot\js\highlightInput.js" />
+	</ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\subtrack.DAL\subtrack.DAL.csproj" />
-    </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Humanizer.Core" Version="2.14.1" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\subtrack.DAL\subtrack.DAL.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/subtrack.MAUI/subtrack.MAUI.csproj
+++ b/subtrack.MAUI/subtrack.MAUI.csproj
@@ -13,16 +13,19 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <EnableDefaultCssItems>false</EnableDefaultCssItems>
 
-        <!-- Display name -->
-        <ApplicationTitle>subtrack.MAUI</ApplicationTitle>
-
         <!-- App Identifier -->
-        <ApplicationId>com.companyname.subtrack.maui</ApplicationId>
         <ApplicationIdGuid>534AC803-FA5C-4FC7-9B68-B72408BE0A72</ApplicationIdGuid>
+		
+		<!-- Remove ".Test" when making an APK release but do not commit -->
+        <!-- Display name -->
+        <ApplicationTitle>subtrack.Test</ApplicationTitle>
+		<!-- App Identifier -->
+        <ApplicationId>com.companyname.subtrack.test</ApplicationId>
 
         <!-- Versions -->
-        <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
         <ApplicationVersion>1</ApplicationVersion>
+        <!-- Update when merging from dev to master -->
+        <ApplicationDisplayVersion>1.0.0</ApplicationDisplayVersion>
 
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>


### PR DESCRIPTION
closes #107
- updated readme to include how a release is created
- added suffix to the app and the appid so that developers that have the actual app installed can still test the app without affecting their actual data

The commit ".test" contains all changes to the csproj file. The other commits just formats the csproj fike and updates readme