### PR TITLE
revert

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ After making changes to any entity you need to add a migration and update the da
   - Update the Roadmap
 - Git pull master
 - Open up *subtrack.maui.csproj*
-    - Set the value of application Id to `<ApplicationId>com.companyname.subtrack</ApplicationId>``
+    - Set the value of application Id to `<ApplicationId>com.companyname.subtrack</ApplicationId>`
     - Set the value of application Title `<ApplicationTitle>subtrack</ApplicationTitle>`
 - Inside Visual Studio set build mode to **Release**
 - Build the project

--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ After making changes to any entity you need to add a migration and update the da
 ## Creating a Release
 - Check if there are any open issues that are required for the release
 - Briefly test the app's functionality on the dev branch and open any necessary issues
-- Open a PR from dev to master branch that should contain the release number in the title
-  - Update the application version `<ApplicationDisplayVersion></ApplicationDisplayVersion>` inside *subtrack.maui.csproj*. This should be set to the same value as the release version
+- Open a PR from dev to master branch that should contain the release number in the title  
   - Update the Roadmap
 - Git pull master
 - Open up *subtrack.maui.csproj*

--- a/subtrack.MAUI/subtrack.MAUI.csproj
+++ b/subtrack.MAUI/subtrack.MAUI.csproj
@@ -25,7 +25,7 @@
 		<!-- Versions -->
 		<ApplicationVersion>1</ApplicationVersion>
 		<!-- Update when merging from dev to master -->
-		<ApplicationDisplayVersion>2.0.0</ApplicationDisplayVersion>
+		<ApplicationDisplayVersion>1.0.0</ApplicationDisplayVersion>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>

--- a/subtrack.MAUI/subtrack.MAUI.csproj
+++ b/subtrack.MAUI/subtrack.MAUI.csproj
@@ -20,7 +20,7 @@
 		<!-- Display name -->
 		<ApplicationTitle>subtrack.Test</ApplicationTitle>
 		<!-- App Identifier -->
-		<ApplicationId>com.companyname.subtrack.test</ApplicationId>
+		<ApplicationId>com.code2gether.subtrack.test</ApplicationId>
 
 		<ApplicationVersion>1</ApplicationVersion>
 		<ApplicationDisplayVersion>1.0.0</ApplicationDisplayVersion>

--- a/subtrack.MAUI/subtrack.MAUI.csproj
+++ b/subtrack.MAUI/subtrack.MAUI.csproj
@@ -22,9 +22,7 @@
 		<!-- App Identifier -->
 		<ApplicationId>com.companyname.subtrack.test</ApplicationId>
 
-		<!-- Versions -->
 		<ApplicationVersion>1</ApplicationVersion>
-		<!-- Update when merging from dev to master -->
 		<ApplicationDisplayVersion>1.0.0</ApplicationDisplayVersion>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>


### PR DESCRIPTION
application display doesn't seem to be working for now - its inconsistent and causes errors with no solutions. Its fine not specifying the version considering we are in alpha. will look in to it more in the future alternatively deploy via CLI or have our own versioning on an about page. Hoping it is fixed in .net 8