### PR TITLE
#115 Added call to GetDueClass method in monthly page.

### DIFF
--- a/subtrack.MAUI/Shared/Components/SubscriptionMonthItem.razor
+++ b/subtrack.MAUI/Shared/Components/SubscriptionMonthItem.razor
@@ -17,8 +17,11 @@
                     <div class="text-truncate flex-grow-1">@sub.Name</div>
                     <div class="text-end flex-shrink-1" style="flex-basis: 7rem;">@($"{sub.Cost:C}")</div>
                 </div>
+                @{
+                    int daysUntilDue = (int)(sub.LastPayment - DateTime.Now.Date).TotalDays;
+                }
                 <div class="d-flex justify-content-between fs-6">
-                    <div>@($"{sub.LastPayment.Day}{GetDateSuffix(sub.LastPayment.Day)}")</div>
+                    <div class="@CssUtil.GetDueClass(daysUntilDue)">@($"{sub.LastPayment.Day}{GetDateSuffix(sub.LastPayment.Day)}")</div>
                     <div class="text-end">
                         @if (sub.IsAutoPaid)
                         {


### PR DESCRIPTION
Added call to `GetDueClass` method in `SubscriptionMonthItem.razor`

Result: 
> warning

![image](https://github.com/Code2Gether-Discord/subtrack/assets/7747808/c8e074a5-cd5f-4120-af4a-e99834ad6906)

> overdue

![image](https://github.com/Code2Gether-Discord/subtrack/assets/7747808/b0229ea4-7f86-46c3-9c37-e566bb1773a9)


closes #115 