### PR TITLE
Preserves newline in subscription description

### DIFF
--- a/subtrack.MAUI/Pages/SubscriptionDetails.razor
+++ b/subtrack.MAUI/Pages/SubscriptionDetails.razor
@@ -66,7 +66,7 @@ else
         </div>
         @if (!string.IsNullOrWhiteSpace(_subscription.Description))
         {
-            <div class="row border-bottom py-2 d-flex justify-content-center text-break">
+            <div class="row border-bottom py-2 d-flex justify-content-center text-break" style="white-space: pre-line">
                 @_subscription.Description
             </div>
         }


### PR DESCRIPTION
Closes #129 

![image](https://github.com/Code2Gether-Discord/subtrack/assets/12110372/cbc91eac-3a42-4b9c-91dc-efd97012ef21)
