### PR TITLE
Monthly page autopaid subs are only displayed in months that have other subs 

### DIFF
--- a/subtrack.MAUI/Services/MonthlyPageCalculator.cs
+++ b/subtrack.MAUI/Services/MonthlyPageCalculator.cs
@@ -36,7 +36,10 @@ namespace subtrack.MAUI.Services
                           MonthDate = new DateTime(g.Key.Year, g.Key.Month, 1),
                           Subscriptions = g.OrderBy(s => s.LastPayment).ToList(),
                           Cost = _subscriptionsCalculator.GetTotalCost(g)
-                      }).GroupBy(r => r.MonthDate.Year).ToDictionary(k => k.Key, v => v.ToList());
+                      })
+                 .GroupBy(r => r.MonthDate.Year)
+                 .OrderBy(g => g.Key)
+                 .ToDictionary(k => k.Key, v => v.ToList());
         }
     }
 }


### PR DESCRIPTION
closes #151 
should probably also close #148

The years inside the dictionary were not ordered by causing the sub to be displayed at the bottom of the page instead of on the top