### PR TITLE
#147 Changed status bar color for android.

### DIFF
--- a/subtrack.MAUI/Platforms/Android/Resources/values/colors.xml
+++ b/subtrack.MAUI/Platforms/Android/Resources/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="colorPrimary">#512BD4</color>
-    <color name="colorPrimaryDark">#2B0B98</color>
+    <color name="colorPrimaryDark">#000000</color>
     <color name="colorAccent">#2B0B98</color>
 </resources>


### PR DESCRIPTION
Closes #147 

- Changed the color of the `Android` status bar according to the articles mentioned on #147.

Screenshot for reference:

![image](https://github.com/Code2Gether-Discord/subtrack/assets/7747808/bec7f599-1155-4677-a0bb-7b80406c1661)